### PR TITLE
Add build and clang-format CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 80
+BreakBeforeBraces: Attach

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Falcon Core
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ develop ]
 
 jobs:
   build-linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build Falcon Core
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          cmake \
+          build-essential \
+          libzmq3-dev \
+          pkg-config \
+          git \
+          clang-format
+
+    - name: Run format check
+      run: |
+        sh scripts/format.sh
+
+        # Check for any changes caused by formatting
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo "Code is not properly formatted. Please run './scripts/format.sh' locally and commit the changes."
+          git --no-pager diff
+          exit 1
+        fi
+
+    - name: Configure CMake
+      run: |
+        mkdir -p build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Debug
+
+    - name: Build project
+      run: |
+        cd build
+        make -j$(nproc)

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,1 @@
+find . -path ./build -prune -o -path ./.git -prune -o -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|hh\|c\|hxx\)' -print0 | xargs -0 clang-format -i


### PR DESCRIPTION
This is a minimal Github Actions pipeline that ensures there are no formatting errors and that the C++ code compiles successfully.