### PR TITLE
New extensions layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/api/*
 
 # Extensions in development
 extensions/*
+
+cmake_cache/

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -6,25 +6,54 @@ ignorePaths:
 dictionaries:
   - cpp
 words:
+  - AABB
   - backend
   - cppzmq
   - DCMAKE
   - Digilynx
+  - bugprone
+  - channelmap
+  - cppdbg
+  - cppzmq
+  - DCMAKE
+  - Digilynx
+  - dummysink
+  - endmacro
+  - ETERM
+  - FETCHCONTENT
+  - flatbuffer
   - FLATBUFFERS
   - flatc
   - frontend
   - GRAPHERROR
+  - headeronly
   - isautonomous
   - keypair
+  - latencybenchmark
+  - libzmq
+  - multichannelfilter
+  - nchannels
+  - ncipollo
+  - neuralynx
   - Neuro
+  - nlxreader
   - nlxrecord
   - nlxtestbench
+  - npackets
   - nsamples
+  - ontime
+  - optvallen
   - outoforder
   - recvlen
   - REGISTERPROCESSOR
   - rootproject
   - stdev
+  - stim
+  - streamheader
+  - taskset
   - unoptimized
   - Wextra
   - Wunused
+  - xipplib
+  - ZMQF
+  - zscore

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -3,18 +3,22 @@ version: "0.2"
 language: en
 ignorePaths:
   - build/**
+  - cmake_cache/**
+  - extensions/**
 dictionaries:
   - cpp
 words:
   - AABB
+  - ALSA
   - backend
-  - cppzmq
-  - DCMAKE
-  - Digilynx
   - bugprone
+  - buildconstant
   - channelmap
+  - COPYONLY
   - cppdbg
   - cppzmq
+  - curdir
+  - datatypebuffer
   - DCMAKE
   - Digilynx
   - dummysink
@@ -24,13 +28,18 @@ words:
   - flatbuffer
   - FLATBUFFERS
   - flatc
+  - flathash
   - frontend
   - GRAPHERROR
   - headeronly
   - isautonomous
+  - kbhit
   - keypair
   - latencybenchmark
+  - levelcrossingdetector
+  - LIBCXX
   - libzmq
+  - LLNL
   - multichannelfilter
   - nchannels
   - ncipollo
@@ -50,10 +59,13 @@ words:
   - stdev
   - stim
   - streamheader
+  - SUBDIRLIST
   - taskset
   - unoptimized
   - Wextra
+  - WHOLELIBS
   - Wunused
   - xipplib
+  - YAMLCPP
   - ZMQF
   - zscore

--- a/extensions.txt
+++ b/extensions.txt
@@ -1,2 +1,0 @@
-enable, extension name, extension path, extension version (optional)
-dev, core, extensions/falcon-fklab-extensions

--- a/falcon/CMakeLists.txt
+++ b/falcon/CMakeLists.txt
@@ -174,7 +174,7 @@ if (COMPILE_EXTENSIONS)
             endforeach ()
 
         elseif (EXISTS "${FALCON_PATH}/src")
-            message("Adding new layout processor natively: ${EXT_NAME}")
+            message("Adding processor: ${EXT_NAME}")
             add_subdirectory("${FALCON_PATH}" "${CMAKE_CURRENT_BINARY_DIR}/extensions/${EXT_NAME}")
 
             if (TARGET ${EXT_NAME})

--- a/falcon/CMakeLists.txt
+++ b/falcon/CMakeLists.txt
@@ -1,31 +1,31 @@
 cmake_minimum_required(VERSION 3.16)
 ENABLE_LANGUAGE(CXX)
 
-MACRO(SUBDIRLIST result curdir)
-    FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
-    SET(dirlist "")
-    FOREACH (child ${children})
-        IF (IS_DIRECTORY ${curdir}/${child})
-            LIST(APPEND dirlist ${child})
-        ENDIF ()
-    ENDFOREACH ()
-    SET(${result} ${dirlist})
-ENDMACRO()
+macro(SUBDIRLIST result curdir)
+    file(GLOB children RELATIVE ${curdir} ${curdir}/*)
+    set(dirlist "")
+    foreach (child ${children})
+        if (IS_DIRECTORY ${curdir}/${child})
+            list(APPEND dirlist ${child})
+        endif ()
+    endforeach ()
+    set(${result} ${dirlist})
+endmacro()
 
 project(falcon)
 
 set(PLATFORM_LINK_LIBRARIES rt dl)
 
-MESSAGE("${CMAKE_BUILD_TYPE}")
+message("${CMAKE_BUILD_TYPE}")
 
 add_definitions(-DG2_DYNAMIC_LOGGING)
 
 
-Set(BUILD_RESOURCES_PATH ${rootproject_BINARY_DIR})
+set(BUILD_RESOURCES_PATH ${rootproject_BINARY_DIR})
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    Set(RESOURCES_PATH ${rootproject_BINARY_DIR} CACHE STRING "")
+    set(RESOURCES_PATH ${rootproject_BINARY_DIR} CACHE STRING "")
 else()
-    Set(RESOURCES_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE STRING "")
+    set(RESOURCES_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE STRING "")
 endif()
 
 mark_as_advanced(RESOURCES_PATH)
@@ -53,9 +53,7 @@ option(COMPILE_EXTENSIONS "compile all extensions" ON)
 
 if (COMPILE_EXTENSIONS)
 
-
-    # get real absolute extension paths
-    SET(REAL_FALCON_PATHS, "")
+    set(REAL_FALCON_PATHS "")
 
     foreach (FALCON_PATH ${EXTENSION_PATHS})
         # Use project root instead of `falcon/` when parsing a relative path
@@ -64,20 +62,20 @@ if (COMPILE_EXTENSIONS)
         endif()
 
         get_filename_component(FALCON_PATH ${FALCON_PATH} REALPATH)
-        LIST(APPEND REAL_FALCON_PATHS ${FALCON_PATH})
+        list(APPEND REAL_FALCON_PATHS ${FALCON_PATH})
     endforeach ()
 
     # first, let's add all include directories
     foreach (FALCON_PATH ${REAL_FALCON_PATHS})
 
-        MESSAGE("Adding include directories for extension: ${FALCON_PATH}")
+        message("Adding include directories for extension: ${FALCON_PATH}")
 
         if (EXISTS ${FALCON_PATH}/lib)
             include_directories(${FALCON_PATH}/lib)
         endif ()
 
         if (EXISTS ${FALCON_PATH}/resources)
-            MESSAGE("Adding resources for extension: ${FALCON_PATH}")
+            message("Adding resources for extension: ${FALCON_PATH}")
             include_directories(${FALCON_PATH}/resources)
         endif ()
 
@@ -92,11 +90,11 @@ if (COMPILE_EXTENSIONS)
     endforeach ()
 
     # next, let's add all libs in extensions
-    SET(ITER 0)
+    set(ITER 0)
 
     foreach (FALCON_PATH ${REAL_FALCON_PATHS})
         if (EXISTS ${FALCON_PATH}/lib/CMakeLists.txt)
-            MESSAGE("Adding libraries for extension: ${FALCON_PATH}")
+            message("Adding libraries for extension: ${FALCON_PATH}")
             add_subdirectory(${FALCON_PATH}/lib ${CMAKE_CURRENT_BINARY_DIR}/lib${ITER})
         endif ()
         math(EXPR ITER "${ITER} + 1")
@@ -108,31 +106,31 @@ if (COMPILE_EXTENSIONS)
 
         if (EXISTS ${FALCON_PATH}/datatypes)
 
-            MESSAGE("Adding datatypes for extension: ${FALCON_PATH}")
+            message("Adding datatypes for extension: ${FALCON_PATH}")
 
             SUBDIRLIST(DATATYPES "${FALCON_PATH}/datatypes")
 
             set(EXCLUDED_ITEMS "")
             if (EXISTS ${FALCON_PATH}/datatypes/exclude.txt)
-                FILE(STRINGS ${FALCON_PATH}/datatypes/exclude.txt EXCLUDED_ITEMS)
+                file(STRINGS ${FALCON_PATH}/datatypes/exclude.txt EXCLUDED_ITEMS)
             endif ()
 
-            FOREACH (DATATYPE ${DATATYPES})
-                LIST(FIND EXCLUDED_ITEMS ${DATATYPE} DO_EXCLUDE)
+            foreach (DATATYPE ${DATATYPES})
+                list(FIND EXCLUDED_ITEMS ${DATATYPE} DO_EXCLUDE)
                 if (DO_EXCLUDE GREATER -1)
-                    MESSAGE("Excluding data type: ${DATATYPE}")
+                    message("Excluding data type: ${DATATYPE}")
                     continue()
                 else ()
                     if (EXISTS "${FALCON_PATH}/datatypes/${DATATYPE}/CMakeLists.txt")
-                        MESSAGE("Adding data type: ${DATATYPE}")
+                        message("Adding data type: ${DATATYPE}")
                         add_subdirectory(${FALCON_PATH}/datatypes/${DATATYPE} ${CMAKE_CURRENT_BINARY_DIR}/datatypes/${DATATYPE})
                         if (TARGET ${DATATYPE})
                             add_dependencies(${DATATYPE} datatypebuffer)
-                            LIST(APPEND DATATYPE_LIBS ${DATATYPE})
+                            list(APPEND DATATYPE_LIBS ${DATATYPE})
                         endif ()
                     endif ()
                 endif ()
-            ENDFOREACH ()
+            endforeach ()
 
         endif ()
 
@@ -141,30 +139,31 @@ if (COMPILE_EXTENSIONS)
     # then, let's add all processors
 
     foreach (FALCON_PATH ${REAL_FALCON_PATHS})
+        get_filename_component(EXT_NAME "${FALCON_PATH}" NAME)
 
         if (EXISTS ${FALCON_PATH}/processors)
 
-            MESSAGE("Adding processors for extension: ${FALCON_PATH}")
+            message("Adding processors for extension: ${FALCON_PATH}")
 
             SUBDIRLIST(PROCESSORS "${FALCON_PATH}/processors")
 
             set(EXCLUDED_ITEMS "")
             if (EXISTS ${FALCON_PATH}/processors/exclude.txt)
-                FILE(STRINGS ${FALCON_PATH}/processors/exclude.txt EXCLUDED_ITEMS)
+                file(STRINGS ${FALCON_PATH}/processors/exclude.txt EXCLUDED_ITEMS)
             endif ()
 
-            FOREACH (PROCESSOR ${PROCESSORS})
-                LIST(FIND EXCLUDED_ITEMS ${PROCESSOR} DO_EXCLUDE)
+            foreach (PROCESSOR ${PROCESSORS})
+                list(FIND EXCLUDED_ITEMS ${PROCESSOR} DO_EXCLUDE)
                 if (DO_EXCLUDE GREATER -1)
-                    MESSAGE("Excluding processor: ${PROCESSOR}")
+                    message("Excluding processor: ${PROCESSOR}")
                     continue()
                 else ()
                     if (EXISTS "${FALCON_PATH}/processors/${PROCESSOR}/CMakeLists.txt")
-                        MESSAGE("Adding processor: ${PROCESSOR}")
+                        message("Adding processor: ${PROCESSOR}")
                         add_subdirectory(${FALCON_PATH}/processors/${PROCESSOR} ${CMAKE_CURRENT_BINARY_DIR}/processors/${PROCESSOR})
                         if (TARGET ${PROCESSOR})
                             add_dependencies(${PROCESSOR} datatypebuffer)
-                            LIST(APPEND PROCESSOR_LIBS ${PROCESSOR})
+                            list(APPEND PROCESSOR_LIBS ${PROCESSOR})
                         endif ()
                         if (EXISTS "${FALCON_PATH}/processors/${PROCESSOR}/doc.yaml")
                             configure_file(${FALCON_PATH}/processors/${PROCESSOR}/doc.yaml
@@ -172,19 +171,28 @@ if (COMPILE_EXTENSIONS)
                         endif ()
                     endif ()
                 endif ()
-            ENDFOREACH ()
+            endforeach ()
+
+        elseif (EXISTS "${FALCON_PATH}/src")
+            message("Adding new layout processor natively: ${EXT_NAME}")
+            add_subdirectory("${FALCON_PATH}" "${CMAKE_CURRENT_BINARY_DIR}/extensions/${EXT_NAME}")
+
+            if (TARGET ${EXT_NAME})
+                add_dependencies(${EXT_NAME} datatypebuffer)
+                list(APPEND PROCESSOR_LIBS ${EXT_NAME})
+            endif ()
 
         endif ()
 
     endforeach ()
 
     # and finally add all tools
-    SET(ITER 0)
+    set(ITER 0)
 
     foreach (FALCON_PATH ${REAL_FALCON_PATHS})
 
         if (EXISTS ${FALCON_PATH}/tools/CMakeLists.txt)
-            MESSAGE("Adding tools from extension: ${FALCON_PATH}")
+            message("Adding tools from extension: ${FALCON_PATH}")
             add_subdirectory(${FALCON_PATH}/tools ${CMAKE_CURRENT_BINARY_DIR}/tools${ITER})
         endif ()
 
@@ -208,20 +216,20 @@ target_link_libraries(falcon yaml-cpp zmq flatbuffers ${PLATFORM_LINK_LIBRARIES}
 # linked at all because none of their exported symbols are explicitly used in falcon. Same is true for (part of)
 # the disruptor and utilities libraries
 
-SET(WHOLELIBS -Wl,--whole-archive g3log logging units::units utilities options disruptor ${DATATYPE_LIBS} ${PROCESSOR_LIBS} -Wl,--no-whole-archive)
+set(WHOLELIBS -Wl,--whole-archive g3log logging units::units utilities options disruptor ${DATATYPE_LIBS} ${PROCESSOR_LIBS} -Wl,--no-whole-archive)
 target_link_libraries(falcon ${WHOLELIBS})
 
 install(TARGETS falcon CONFIGURATIONS Release RUNTIME DESTINATION bin)
 if (COMPILE_EXTENSIONS)
 
         foreach (FALCON_PATH ${REAL_FALCON_PATHS})
-            FILE(GLOB RESOURCES RELATIVE ${FALCON_PATH}/resources ${FALCON_PATH}/resources/*)
-            ADD_CUSTOM_COMMAND(TARGET falcon
+            file(GLOB RESOURCES RELATIVE ${FALCON_PATH}/resources ${FALCON_PATH}/resources/*)
+            add_custom_command(TARGET falcon
                     POST_BUILD
                     COMMAND mkdir -p ${BUILD_RESOURCES_PATH}/resources/${RESOURCE}
                     )
             foreach (RESOURCE ${RESOURCES})
-                ADD_CUSTOM_COMMAND(TARGET falcon
+                add_custom_command(TARGET falcon
                         POST_BUILD
                         COMMAND cp -r ${FALCON_PATH}/resources/${RESOURCE} ${BUILD_RESOURCES_PATH}/resources/${RESOURCE}/
                         )

--- a/falcon/ringbuffer.hpp
+++ b/falcon/ringbuffer.hpp
@@ -42,7 +42,7 @@ class RingBuffer : public disruptor::Sequencer {
     /**
      * Construct a RingBuffer with the full option set.
      *
-     * @param prototype of data object to store in ringbuffer
+     * @param prototype of data object to store in ring buffer
      * @param buffer_size of the RingBuffer, must be a power of 2.
      * @param claim_strategy_option threading strategy for publishers claiming
      * entries in the ring.

--- a/scripts/cmake/ParseExtensions.cmake
+++ b/scripts/cmake/ParseExtensions.cmake
@@ -1,27 +1,15 @@
+message(STATUS "Scanning extensions/ directory...")
+
 set(EXT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extensions")
 
-if(EXISTS "${EXT_DIR}" AND IS_DIRECTORY "${EXT_DIR}")
-    message(STATUS "Scanning extensions directory...")
+file(GLOB subdirs RELATIVE "${EXT_DIR}" "${EXT_DIR}/*")
 
-    file(GLOB subdirs RELATIVE "${EXT_DIR}" "${EXT_DIR}/*")
+foreach(ext_name ${subdirs})
+    set(abs_ext_path "${EXT_DIR}/${ext_name}")
+    message(STATUS "Found extension: ${ext_name} at ${abs_ext_path}")
 
-    foreach(ext_name ${subdirs})
-        if(IS_DIRECTORY "${EXT_DIR}/${ext_name}")
+    list(APPEND _extension_names "${ext_name} - ${abs_ext_path} - local")
+    list(APPEND EXTENSION_PATHS "${abs_ext_path}")
+    list(APPEND INSTALLED_EXTENSIONS ${ext_name})
 
-            if(ext_name IN_LIST INSTALLED_EXTENSIONS)
-                message(STATUS "Skip duplicate. Extension ${ext_name} already installed")
-                continue()
-            endif()
-
-            set(abs_ext_path "${EXT_DIR}/${ext_name}")
-            message(STATUS "Found extension: ${ext_name} at ${abs_ext_path}")
-
-            list(APPEND _extension_names "${ext_name} - ${abs_ext_path} - local")
-            list(APPEND EXTENSION_PATHS "${abs_ext_path}")
-            list(APPEND INSTALLED_EXTENSIONS ${ext_name})
-
-        endif()
-    endforeach()
-else()
-    message(STATUS "No extensions folder found.")
-endif()
+endforeach()

--- a/scripts/cmake/ParseExtensions.cmake
+++ b/scripts/cmake/ParseExtensions.cmake
@@ -1,101 +1,27 @@
+set(EXT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extensions")
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extensions.txt")
-	message(STATUS "Found extensions.txt")
+if(EXISTS "${EXT_DIR}" AND IS_DIRECTORY "${EXT_DIR}")
+    message(STATUS "Scanning extensions directory...")
 
-	file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/extensions.txt" extensions)
+    file(GLOB subdirs RELATIVE "${EXT_DIR}" "${EXT_DIR}/*")
 
-	# remove header row
-	list(REMOVE_AT extensions 0)
+    foreach(ext_name ${subdirs})
+        if(IS_DIRECTORY "${EXT_DIR}/${ext_name}")
 
-	list(LENGTH extensions nextensions)
+            if(ext_name IN_LIST INSTALLED_EXTENSIONS)
+                message(STATUS "Skip duplicate. Extension ${ext_name} already installed")
+                continue()
+            endif()
 
-	message(STATUS "Found ${nextensions} extensions.")
+            set(abs_ext_path "${EXT_DIR}/${ext_name}")
+            message(STATUS "Found extension: ${ext_name} at ${abs_ext_path}")
 
-	foreach(ext ${extensions})
+            list(APPEND _extension_names "${ext_name} - ${abs_ext_path} - local")
+            list(APPEND EXTENSION_PATHS "${abs_ext_path}")
+            list(APPEND INSTALLED_EXTENSIONS ${ext_name})
 
-		# convert from comma separated string to list
-		string(REPLACE " " "" ext ${ext})
-		string(REPLACE "," ";" ext ${ext})
-		list(LENGTH ext nitems)
-
-		# we need at least enabled, name and path
-		if (nitems LESS 3)
-			continue()
-		endif()
-
-		# only add enabled extensions
-		list(GET ext 0 ext_enabled)
-		list(GET ext 1 ext_name)
-		list(GET ext 2 ext_path)
-
-		if(ext_enabled)
-			if(ext_name IN_LIST INSTALLED_EXTENSIONS)
-				message(STATUS "Skip duplicate. Extension ${ext_name} already installed")
-				continue()
-			endif()
-
-			if(ext_enabled STREQUAL "dev")
-				get_filename_component(abs_ext_path "${ext_path}" ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
-
-				if(NOT EXISTS "${abs_ext_path}")
-					message(WARNING "Extension \"${ext_name}\" not found at: ${abs_ext_path}. Skipping...")
-					continue()
-				endif()
-
-				string(TOUPPER ${ext_name} ext_name_upper)
-				set(FETCHCONTENT_SOURCE_DIR_${ext_name_upper} "${abs_ext_path}")
-				message(STATUS "Adding ${ext_name} in development mode from: ${abs_ext_path}")
-			
-			endif()
-
-			# check if optional version is given
-			if (nitems GREATER_EQUAL 4)
-				list(GET ext 3 ext_version)
-				FetchContent_Declare(
-					${ext_name}
-					GIT_REPOSITORY ${ext_path}
-					GIT_SHALLOW	ON
-					GIT_TAG ${ext_version}
-				)
-				message(STATUS "Declared ${ext_name} (version ${ext_version}) at ${ext_path}.")
-
-			else()
-				FetchContent_Declare(
-					${ext_name}
-					GIT_REPOSITORY ${ext_path}
-					GIT_SHALLOW	ON
-				)
-				message(STATUS "Declared ${ext_name} at ${ext_path}.")
-				set(ext_version "master-branch")
-			endif()
-
-			# populate
-			FetchContent_GetProperties(${ext_name})
-			if(NOT ${ext_name}_POPULATED)
-				message(STATUS "Populating ${ext_name} ...")
-				FetchContent_MakeAvailable(${ext_name})
-				message(STATUS "Done.")
-			endif()
-			include_directories(BEFORE SYSTEM "${$ext_name}_SOURCE_DIR}" ${${ext_name}_BINARY_DIR}/include)
-
-			if(ext_enabled STREQUAL "dev")
-				list(APPEND _extension_names "${ext_name} - ${ext_path} - dev")
-			else()
-				list(APPEND _extension_names "${ext_name} - ${ext_path} - ${ext_version}")
-			endif()
-
-
-			# add to list of extensions
-			list(APPEND EXTENSION_PATHS ${${ext_name}_SOURCE_DIR})
-
-			# add to installed extensions
-			list(APPEND INSTALLED_EXTENSIONS ${ext_name})
-
-		else()
-			message(STATUS "Extension ${ext_name} is not enabled. Skipped.")
-		endif()
-
-	endforeach()
+        endif()
+    endforeach()
 else()
-	message(STATUS "No extensions found.")
+    message(STATUS "No extensions folder found.")
 endif()

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 cd build
-make -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
+make -j$(nproc 2>/dev/null)
 mkdir -p debug
 cp falcon/falcon debug/
+cp falcon/tools0/nlxtestbench/nlxtestbench debug/ || true


### PR DESCRIPTION
New extension layout for simpler extension detection. Each folder under `extensions/` is added as extension.

Extensions are expected to have `src/` folder at top.

This change is backwards compatible so that `fklab` extensions with the top level `processors/` is still supported.

Documentation should be updated in another PR to inform Falcon users.